### PR TITLE
6.2.3 image

### DIFF
--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,8 +1,12 @@
-FROM cimg/base:2021.10
+# vim:set ft=dockerfile:
+
+# Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
+
+FROM cimg/base:2022.01
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV REDIS_VERSION=6.2.6
+ENV REDIS_VERSION=6.2.3
 
 USER root
 

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 6.2/Dockerfile -t cimg/redis:6.2.3  -t cimg/redis:6.2 .
+docker push cimg/redis:6.2.3
+docker push cimg/redis:6.2


### PR DESCRIPTION
Attempting to generate a 6.2.3 Redis image, although I'm wondering if this is right as it has updated the `6.2/Dockerfile` image and not sure you wanted it changed from 6.2.6 to 6.2.3.

This is what I ran to generate this:

```sh
./shared/gen-dockerfiles.sh 6.2.3
./build-images.sh
git add . # commit, push etc
```