### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.3
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=redis
 parent=base
 variants=()
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
This PR adds multi architecture images with arm64 support

# Reasons
Enables arm64 support using the updating tooling in cimg-shared and cimg-orb

Test build: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-redis/218/workflows/c7ca7d1f-dd63-4d22-9acf-2773c0e93eab/jobs/222

Note: like python, the image builds for Redis are significantly slower with buildx so we will have to look into ways to speed this up in the future

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)